### PR TITLE
fix: component dehydration

### DIFF
--- a/src/SelectTree.php
+++ b/src/SelectTree.php
@@ -121,6 +121,8 @@ class SelectTree extends Field implements HasAffixActions
         $this->suffixActions([
             static fn (SelectTree $component): ?Action => $component->getCreateOptionAction(),
         ]);
+
+        $this->dehydrated(false);
     }
 
     private function buildTree(): Collection


### PR DESCRIPTION
When using relationships, fields must not be dehydrated, otherwise, (when strict) a `MassAssignmentException` is thrown.

As far i can see, this plugin only supports relationships, right? If yes, its fine as is. If not (supports arrays too) we need to add this fix only inside `relationship()` method.

Thanks!