### PR TITLE
fix reactive select

### DIFF
--- a/resources/views/select-tree.blade.php
+++ b/resources/views/select-tree.blade.php
@@ -12,6 +12,7 @@
 
 <x-dynamic-component :component="$getFieldWrapperView()" :field="$field">
     <div
+        wire:key="{{ rand() }}"
         wire:ignore
         x-ignore
         @if (FilamentView::hasSpaMode())


### PR DESCRIPTION
Fixes: https://github.com/CodeWithDennis/filament-select-tree/pull/84#issuecomment-1950230234

I think thats why you've reverted this? https://github.com/CodeWithDennis/filament-select-tree/commit/b2c66ad9cc9cd51291d6ece5a623803348a46248. TBH, idk why this solves the problem, `wire:key` is commonly used for DOM Diffing issues on loops and no other Filament field has that attr defined.

Sorry about that one too.