### PR TITLE
Fix: For multiple trees

### DIFF
--- a/src/SelectTree.php
+++ b/src/SelectTree.php
@@ -148,8 +148,9 @@ class SelectTree extends Field implements HasAffixActions
             $nullParentQuery = $this->evaluate($this->modifyQueryUsing, ['query' => $nullParentQuery]);
         }
 
-        // If we're at the child level and a modification callback is provided, apply it to non null query
+        // If a modification callback is provided, apply it to both querys
         if ($this->modifyChildQueryUsing) {
+            $nullParentQuery = $this->evaluate($this->modifyChildQueryUsing, ['query' => $nullParentQuery]);
             $nonNullParentQuery = $this->evaluate($this->modifyChildQueryUsing, ['query' => $nonNullParentQuery]);
         }
 


### PR DESCRIPTION
If there is more than one tree (more than one root element with null parent_id) I need filter the trees using modifyChildQueryUsing, but there is no efect on root elements, and it's not possible to show ONLY elements of one tree, insted the plugin show elements of the filtered tree plus other roots elements of different trees.