### PR TITLE
Add CreateOptionModalHeading Method to SelectTree

### DIFF
--- a/src/SelectTree.php
+++ b/src/SelectTree.php
@@ -584,4 +584,11 @@ class SelectTree extends Field implements HasAffixActions
 
         return $action;
     }
+
+    public function createOptionModalHeading(string | Closure | null $heading): static
+    {
+        $this->createOptionModalHeading = $heading;
+
+        return $this;
+    }
 }


### PR DESCRIPTION
There is no method to change the modal heading for a SelectTree. I added this method in my PR.