### PR TITLE
Improve tags (using filament translations)

### DIFF
--- a/src/SelectTree.php
+++ b/src/SelectTree.php
@@ -36,8 +36,6 @@ class SelectTree extends Field implements HasAffixActions
 
     protected bool $alwaysOpen = false;
 
-    protected string $emptyLabel = '';
-
     protected bool $independent = true;
 
     protected ?string $customKey = null;
@@ -135,6 +133,8 @@ class SelectTree extends Field implements HasAffixActions
 
             return $component->getCustomKey($record);
         });
+
+        $this->placeholder(static fn (SelectTree $component): ?string => $component->isDisabled() ? null : __('filament-forms::components.select.placeholder'));
 
         $this->suffixActions([
             static fn (SelectTree $component): ?Action => $component->getCreateOptionAction(),
@@ -336,7 +336,7 @@ class SelectTree extends Field implements HasAffixActions
 
     public function emptyLabel(string $emptyLabel): static
     {
-        $this->emptyLabel = $emptyLabel;
+        $this->noSearchResultsMessage($emptyLabel);
 
         return $this;
     }
@@ -457,7 +457,7 @@ class SelectTree extends Field implements HasAffixActions
 
     public function getEmptyLabel(): string
     {
-        return $this->emptyLabel ? $this->evaluate($this->emptyLabel) : __('No options match your search.');
+        return $this->getNoSearchResultsMessage();
     }
 
     public function getDirection(): string


### PR DESCRIPTION
This package has no translations, it only uses 2 labels `placeholder` and `getEmptyLabel` that can be configured. If not configured, they use a default English label from the javascript library.

This PR configures by default the filament labels that already have translations.

In the case of `placeholder`, both `Select` and `SelectTree` implement the `HasPlaceholder` trait. In the `Select` component, a translatable label is set on `setup` function.
https://github.com/filamentphp/forms/blob/3.x/src/Components/Select.php#L195
The same criteria is taken for `SelectTree`.

On the other hand, `getEmptyLabel`, the `Select` component and `SelectTree` implement a `CanBeSearchable` trait, which already has a noSearchResultsMessage property, where it has a translatable label.
https://github.com/filamentphp/forms/blob/3.x/src/Components/Concerns/CanBeSearchable.php#L75
The `getEmptyLabel` and `emptyLabel` functions now calls the trait's methods for compatibility.