### PR TITLE
Bug if BelongsToMany and model::shouldBeStrict

### DIFF
--- a/src/SelectTree.php
+++ b/src/SelectTree.php
@@ -136,6 +136,8 @@ class SelectTree extends Field implements HasAffixActions
             return $component->getCustomKey($record);
         });
 
+        $this->dehydrated(fn (SelectTree $component): bool => ! $component->getRelationship() instanceof BelongsToMany);
+
         $this->suffixActions([
             static fn (SelectTree $component): ?Action => $component->getCreateOptionAction(),
         ]);


### PR DESCRIPTION
Sorry for my English, I'll try to explain the bug.

Assuming that the relation is called `categories`, when doing a save, the `categories` field remains in the form data, and then it would go to the model attributes as another field this field does not give an error because it does not reach the database since `categories` is a relation so it is not configured in `fillable` of the model, so when doing a `fill` of the form data in the model that field is not filled. 

For example, on the Edit page (and the same thing happens on the Create page) https://github.com/filamentphp/panels/blob/3.x/src/Resources/Pages/EditRecord.php#L143 https://github.com/filamentphp/forms/blob/3.x/src/Concerns/HasState.php#L235

The above is not an error, it is the expected behavior.

---
However, using `Model::shouldBeStrict()` (widely recommended to avoid errors in the development stage, for example: https://planetscale.com/blog/laravels-safety-mechanisms) throws an exception when trying to fill a field that is not set to `fillable` in the model.

In these cases, the field must be dehydrated so that it is not attempted to be filled in the model, since the update of that field will not be via the model because it is not a field in the database, but it will be done with the sync of the relationship with the code of the `saveRelationshipsUsing` function.

This idea is copied from the original `Select` component https://github.com/filamentphp/forms/blob/3.x/src/Components/Select.php#L1066
