### PR TITLE
fix: Add support for customizable tree key in SelectTree

### DIFF
--- a/resources/views/select-tree.blade.php
+++ b/resources/views/select-tree.blade.php
@@ -15,7 +15,7 @@
         wire:key="{{ $getTreeKey() }}"
         wire:ignore
         x-ignore
-        @if (FilamentView::hasSpaMode())
+        @if (FilamentView::hasSpaMode(url()->current()))
             ax-load="visible"
         @else
             ax-load

--- a/resources/views/select-tree.blade.php
+++ b/resources/views/select-tree.blade.php
@@ -12,7 +12,7 @@
 
 <x-dynamic-component :component="$getFieldWrapperView()" :field="$field">
     <div
-        wire:key="{{ rand() }}"
+        wire:key="{{ $getTreeKey() }}"
         wire:ignore
         x-ignore
         @if (FilamentView::hasSpaMode())

--- a/src/SelectTree.php
+++ b/src/SelectTree.php
@@ -88,6 +88,8 @@ class SelectTree extends Field implements HasAffixActions
 
     protected Closure|array|null $prepend = null;
 
+    protected Closure|string|null $treeKey = 'defaultTreeKey';
+
     protected function setUp(): void
     {
         // Load the state from relationships using a callback function.
@@ -613,5 +615,17 @@ class SelectTree extends Field implements HasAffixActions
         $this->createOptionModalHeading = $heading;
 
         return $this;
+    }
+
+    public function treeKey(string $treeKey): static
+    {
+        $this->treeKey = $treeKey;
+
+        return $this;
+    }
+
+    public function getTreeKey(): string
+    {
+        return $this->evaluate($this->treeKey);
     }
 }

--- a/src/SelectTree.php
+++ b/src/SelectTree.php
@@ -88,7 +88,7 @@ class SelectTree extends Field implements HasAffixActions
 
     protected Closure|array|null $prepend = null;
 
-    protected Closure|string|null $treeKey = 'defaultTreeKey';
+    protected Closure|string|null $treeKey = 'treeKey';
 
     protected function setUp(): void
     {
@@ -147,6 +147,8 @@ class SelectTree extends Field implements HasAffixActions
         $this->suffixActions([
             static fn (SelectTree $component): ?Action => $component->getCreateOptionAction(),
         ]);
+
+        $this->treeKey('treeKey-'.rand());
     }
 
     protected function buildTree(): Collection


### PR DESCRIPTION
Introduce a `treeKey` property and associated methods to allow customization of the tree identifier. Updated Blade template to use the specified tree key for the `wire:key` attribute to ensure predictable component rendering.

This is to address issue #141 