### PR TITLE
Update tree key value to 'select-tree-key' in SelectTree class

### DIFF
--- a/src/SelectTree.php
+++ b/src/SelectTree.php
@@ -148,7 +148,7 @@ class SelectTree extends Field implements HasAffixActions
             static fn (SelectTree $component): ?Action => $component->getCreateOptionAction(),
         ]);
 
-        $this->treeKey('treeKey-'.rand());
+        $this->treeKey('select-tree-key');
     }
 
     protected function buildTree(): Collection


### PR DESCRIPTION
This pull request updates the `setUp` method in the `SelectTree` component to use a consistent and descriptive key for the tree instead of a randomly generated one. 

Key update:

* [`src/SelectTree.php`](diffhunk://#diff-31ee19e73115d0fc0f45375ffdd429e6d02e2b8a0bd1e0a2fad2745f24c9b20fL151-R151): Replaced the dynamic `treeKey` value (`'treeKey-' . rand()`) with a static and more descriptive key (`'select-tree-key'`) in the `setUp` method. This ensures consistency and predictability in the tree key assignment.


**This should fix the field flickering**