### PR TITLE
Let $enableBranchNode be a Closure or null

### DIFF
--- a/src/SelectTree.php
+++ b/src/SelectTree.php
@@ -50,7 +50,7 @@ class SelectTree extends Field implements HasAffixActions
 
     protected bool $expandSelected = true;
 
-    protected bool $enableBranchNode = false;
+    protected Closure|bool|null $enableBranchNode = false;
 
     protected bool $grouped = true;
 
@@ -406,7 +406,7 @@ class SelectTree extends Field implements HasAffixActions
         return $this;
     }
 
-    public function enableBranchNode(bool $enableBranchNode = true): static
+    public function enableBranchNode(Closure|bool|null $enableBranchNode = true): static
     {
         $this->enableBranchNode = $enableBranchNode;
 

--- a/src/SelectTree.php
+++ b/src/SelectTree.php
@@ -50,7 +50,7 @@ class SelectTree extends Field implements HasAffixActions
 
     protected bool $expandSelected = true;
 
-    protected Closure|bool|null $enableBranchNode = false;
+    protected Closure|bool $enableBranchNode = false;
 
     protected bool $grouped = true;
 
@@ -406,7 +406,7 @@ class SelectTree extends Field implements HasAffixActions
         return $this;
     }
 
-    public function enableBranchNode(Closure|bool|null $enableBranchNode = true): static
+    public function enableBranchNode(Closure|bool $enableBranchNode = true): static
     {
         $this->enableBranchNode = $enableBranchNode;
 


### PR DESCRIPTION
Hello,

I've found myself using this package and needing the branch nodes to dynamically be selectable or not (namely, to be selectable when the selectTree is multiple choice, and not to be when it's not).
I thought it was quite odd that $enableBranchNode was type hinted to be strictly a bool, when the method getEnableBranchNode() already evaluates its value.

I changed it locally and it was working, so I though to make a pull request.
I would like to add tests, but they don't seem to be working out of the box, so if you could guide me on how to add them that would be most appreciated.