### PR TITLE
Add append feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,25 @@ use CodeWithDennis\FilamentSelectTree\SelectTree;
 ])
 ```
 
+If you need to append an item to the tree menu, use the `append` method. This method also accepts an array or a closure.
+
+```php
+->schema([
+    SelectTree::make('category')
+        ->relationship('categories', 'name', 'parent_id')
+        ->enableBranchNode()
+        ->multiple(false)
+        ->append([
+            'name' => 'Uncategorized Records',
+            'value' => -1,
+            'parent' => null, // optional
+            'disabled' => false, // optional
+            'hidden' => false, // optional
+            'children' => [], // optional
+            ])
+    ])
+```
+
 ## Filters
 
 Use the tree in your table filters. Here's an example to show you how.

--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ If you need to append an item to the tree menu, use the `append` method. This me
             'disabled' => false, // optional
             'hidden' => false, // optional
             'children' => [], // optional
-            ])
+        ])
     ])
 ```
 

--- a/src/SelectTree.php
+++ b/src/SelectTree.php
@@ -438,12 +438,8 @@ class SelectTree extends Field implements HasAffixActions
     public function getTree(): Collection|array
     {
         return $this->evaluate($this->buildTree()
-            ->when($this->prepend,
-            fn (Collection $tree) => $tree->prepend($this->evaluate($this->prepend))
-            )
-            ->when($this->append,
-            fn(Collection $tree) => $tree->push($this->evaluate($this->append))
-            )
+            ->when($this->prepend, fn (Collection $tree) => $tree->prepend($this->evaluate($this->prepend)))
+            ->when($this->append, fn(Collection $tree) => $tree->push($this->evaluate($this->append)))
         );
     }
 

--- a/src/SelectTree.php
+++ b/src/SelectTree.php
@@ -88,6 +88,8 @@ class SelectTree extends Field implements HasAffixActions
 
     protected Closure|array|null $prepend = null;
 
+    protected Closure|array|null $append = null;
+
     protected Closure|string|null $treeKey = 'treeKey';
 
     protected function setUp(): void
@@ -311,6 +313,19 @@ class SelectTree extends Field implements HasAffixActions
             $this->prepend['value'] = (string) $this->prepend['value'];
         } else {
             throw new \InvalidArgumentException('The provided prepend value must be an array with "name" and "value" keys.');
+        }
+
+        return $this;
+    }
+
+    public function append(Closure|array|null $append = null): static
+    {
+        $this->append = $this->evaluate($append);
+
+        if (is_array($this->append) && isset($this->append['name'], $this->append['value'])) {
+            $this->append['value'] = (string) $this->append['value'];
+        } else {
+            throw new \InvalidArgumentException('The provided append value must be an array with "name" and "value" keys.');
         }
 
         return $this;

--- a/src/SelectTree.php
+++ b/src/SelectTree.php
@@ -439,7 +439,7 @@ class SelectTree extends Field implements HasAffixActions
     {
         return $this->evaluate($this->buildTree()
             ->when($this->prepend, fn (Collection $tree) => $tree->prepend($this->evaluate($this->prepend)))
-            ->when($this->append, fn(Collection $tree) => $tree->push($this->evaluate($this->append)))
+            ->when($this->append, fn (Collection $tree) => $tree->push($this->evaluate($this->append)))
         );
     }
 

--- a/src/SelectTree.php
+++ b/src/SelectTree.php
@@ -437,8 +437,14 @@ class SelectTree extends Field implements HasAffixActions
 
     public function getTree(): Collection|array
     {
-        return $this->evaluate($this->buildTree()->when($this->prepend,
-            fn (Collection $tree) => $tree->prepend($this->evaluate($this->prepend))));
+        return $this->evaluate($this->buildTree()
+            ->when($this->prepend,
+            fn (Collection $tree) => $tree->prepend($this->evaluate($this->prepend))
+            )
+            ->when($this->append,
+            fn(Collection $tree) => $tree->push($this->evaluate($this->append))
+            )
+        );
     }
 
     public function getResults(): Collection|array|null


### PR DESCRIPTION
Hello,

I found myself using the SelectTree as a grouped Select with collapsible groups for the most part,
and needing to append a special value after the db/relationship-generated ones.

Should be functionally identical to prepend, making use of the `push()` collection method.

Before I make more PRs, are there any workarounds for grouping records into branches that aren't records themselves?
Like an enum value on a column, or a foreign key to a parent-like "groups" table.
If this isn't the right place for that question let me know where I could ask, thanks.