### PR TITLE
4.x: Fix missing parent setup

### DIFF
--- a/src/SelectTree.php
+++ b/src/SelectTree.php
@@ -94,6 +94,8 @@ class SelectTree extends Field implements HasAffixActions
 
     protected function setUp(): void
     {
+        parent::setUp();
+
         // Load the state from relationships using a callback function.
         $this->loadStateFromRelationshipsUsing(static function (self $component): void {
             // Get the current relationship associated with the component.


### PR DESCRIPTION
The parent `Field` class the `SelectTree` extends from, calls in Filament v4 a `setUpHint()` method. Therefore, the `SelectTree::setUp()` method must call the parent `setUp()` method.

Otherwise, hints and hint actions are not rendered.
