### PR TITLE
Let append and prepend be set to null without throwing an exception

### DIFF
--- a/src/SelectTree.php
+++ b/src/SelectTree.php
@@ -329,7 +329,7 @@ class SelectTree extends Field implements HasAffixActions
         if (is_array($this->append) && isset($this->append['name'], $this->append['value'])) {
             $this->append['value'] = (string) $this->append['value'];
         } else if (is_null($this->append)) {
-            # Avoid throwing an exception in case $append is explicitly set to null, or a Closure evaluates to null.
+            // Avoid throwing an exception in case $append is explicitly set to null, or a Closure evaluates to null.
         } else {
             throw new \InvalidArgumentException('The provided append value must be an array with "name" and "value" keys.');
         }

--- a/src/SelectTree.php
+++ b/src/SelectTree.php
@@ -313,6 +313,7 @@ class SelectTree extends Field implements HasAffixActions
 
         if (is_array($this->prepend) && isset($this->prepend['name'], $this->prepend['value'])) {
             $this->prepend['value'] = (string) $this->prepend['value'];
+        } else if (is_null($this->prepend)){
         } else {
             throw new InvalidArgumentException('The provided prepend value must be an array with "name" and "value" keys.');
         }
@@ -326,6 +327,7 @@ class SelectTree extends Field implements HasAffixActions
 
         if (is_array($this->append) && isset($this->append['name'], $this->append['value'])) {
             $this->append['value'] = (string) $this->append['value'];
+        } else if (is_null($this->append)) {
         } else {
             throw new \InvalidArgumentException('The provided append value must be an array with "name" and "value" keys.');
         }

--- a/src/SelectTree.php
+++ b/src/SelectTree.php
@@ -314,6 +314,7 @@ class SelectTree extends Field implements HasAffixActions
         if (is_array($this->prepend) && isset($this->prepend['name'], $this->prepend['value'])) {
             $this->prepend['value'] = (string) $this->prepend['value'];
         } else if (is_null($this->prepend)){
+            # Avoid throwing an exception in case $prepend is explicitly set to null, or a Closure evaluates to null.
         } else {
             throw new InvalidArgumentException('The provided prepend value must be an array with "name" and "value" keys.');
         }
@@ -328,6 +329,7 @@ class SelectTree extends Field implements HasAffixActions
         if (is_array($this->append) && isset($this->append['name'], $this->append['value'])) {
             $this->append['value'] = (string) $this->append['value'];
         } else if (is_null($this->append)) {
+            # Avoid throwing an exception in case $append is explicitly set to null, or a Closure evaluates to null.
         } else {
             throw new \InvalidArgumentException('The provided append value must be an array with "name" and "value" keys.');
         }


### PR DESCRIPTION
Hello,

the `$append`/`$prepend` properties are already `null`able, however when you set them to `null` through the setter methods it triggers the `InvalidArgumentException`.
I would not consider this expected behaviour, especially when passing a `Closure` (which is allowed) that conditionally appends or prepends an item based on a condition, like user permissions.
By adding a single clause that does nothing if `null` is passed in (or if `$prepend`/`$append` _evaluate_ to `null`), expected behaviour is restored.
Let me know if there is a reason it should behave like this, thank you.