### PR TITLE
Feature: Add support for SelectTree without relationship using ->query()

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,15 @@ SelectTree::make('category_id')
     ->relationship('category', 'name', 'parent_id')
 ```
 
+## Usage without relationships
+
+Use the tree without relationship
+
+```php
+SelectTree::make('category_id')
+    ->query(fn() => Category::query(), 'name', 'parent_id')
+```
+
 ## Custom Query
 
 Customize the parent query

--- a/src/SelectTree.php
+++ b/src/SelectTree.php
@@ -15,6 +15,7 @@ use Filament\Schemas\Components\Concerns\HasActions;
 use Filament\Schemas\Components\Contracts\HasAffixActions;
 use Filament\Schemas\Schema;
 use Filament\Support\Facades\FilamentIcon;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Support\Arr;
@@ -54,11 +55,13 @@ class SelectTree extends Field implements HasAffixActions
 
     protected bool $grouped = true;
 
-    protected string|Closure $relationship;
+    protected Closure|Builder|null $query = null;
 
-    protected ?Closure $modifyQueryUsing;
+    protected string|Closure|null $relationship = null;
 
-    protected ?Closure $modifyChildQueryUsing;
+    protected ?Closure $modifyQueryUsing = null;
+
+    protected ?Closure $modifyChildQueryUsing = null;
 
     protected Closure|int $defaultOpenLevel = 0;
 
@@ -158,8 +161,8 @@ class SelectTree extends Field implements HasAffixActions
     protected function buildTree(): Collection
     {
         // Start with two separate query builders
-        $nullParentQuery = $this->getRelationship()->getRelated()->query()->where($this->getParentAttribute(), $this->getParentNullValue());
-        $nonNullParentQuery = $this->getRelationship()->getRelated()->query()->whereNot($this->getParentAttribute(), $this->getParentNullValue());
+        $nullParentQuery = $this->getQuery()->clone()->where($this->getParentAttribute(), $this->getParentNullValue());
+        $nonNullParentQuery = $this->getQuery()->clone()->whereNot($this->getParentAttribute(), $this->getParentNullValue());
 
         // If we're not at the root level and a modification callback is provided, apply it to null query
         if ($this->modifyQueryUsing) {
@@ -272,6 +275,17 @@ class SelectTree extends Field implements HasAffixActions
         return $this;
     }
 
+    public function query(Builder|Closure|null $query, string $titleAttribute, string $parentAttribute, ?Closure $modifyQueryUsing = null, ?Closure $modifyChildQueryUsing = null): static
+    {
+        $this->query = $query;
+        $this->titleAttribute = $titleAttribute;
+        $this->parentAttribute = $parentAttribute;
+        $this->modifyQueryUsing = $modifyQueryUsing;
+        $this->modifyChildQueryUsing = $modifyChildQueryUsing;
+
+        return $this;
+    }
+
     public function withCount(bool $withCount = true): static
     {
         $this->withCount = $withCount;
@@ -333,9 +347,21 @@ class SelectTree extends Field implements HasAffixActions
         return $this;
     }
 
-    public function getRelationship(): BelongsToMany|BelongsTo
+    public function getRelationship(): BelongsToMany|BelongsTo|null
     {
+        if (is_null($this->relationship)) {
+            return null;
+        }
         return $this->getModelInstance()->{$this->evaluate($this->relationship)}();
+    }
+
+    public function getQuery(): ?Builder
+    {
+        if (! is_null($this->query)) {
+            return $this->evaluate($this->query);
+        }
+
+        return $this->getRelationship()->getRelated()->query();
     }
 
     public function getTitleAttribute(): string


### PR DESCRIPTION
This PR introduces the ability to use the SelectTree component without requiring an Eloquent relationship.

Previously, the component only worked when bound to a model relationship via ->relationship(...). However, there are valid use cases where no relationship exists — for example, when selecting navigation points to insert links inside a RichText editor.

To support this, a new ->query(...) method has been added. This allows developers to provide a custom query directly, enabling the SelectTree component to be used more flexibly across different scenarios.

## Key changes:

- Added ->query() method as an alternative to ->relationship(...).
- Ensures that the component can still be used in contexts where no model relationship is defined.
- Keeps backward compatibility with existing ->relationship(...) usage.

## Example usage:

```php
SelectTree::make('category_id')
    ->query(fn() => Category::query(), 'name', 'parent_id')
```

This enhancement makes SelectTree more versatile and applicable beyond relationship-driven use cases.