### PR TITLE
Revised changes

### DIFF
--- a/src/SelectTree.php
+++ b/src/SelectTree.php
@@ -246,7 +246,10 @@ class SelectTree extends Field implements HasAffixActions
         );
 
         // Move any remaining children from the cache into the root of the tree, since their parents do not show up in the result set
-        $resultMap[$parent] = array_merge(...array_values($orphanedResults));
+        $resultMap[$parent] = [];
+        foreach($orphanedResults as $orphanedResult){
+            $resultMap[$parent] += $orphanedResult;
+        }
 
         // Recursively build the tree starting from the root (null parent)
         $rootResults = $resultMap[$parent] ?? [];

--- a/src/SelectTree.php
+++ b/src/SelectTree.php
@@ -223,6 +223,13 @@ class SelectTree extends Field implements HasAffixActions
 
         // Recursively build the tree starting from the root (null parent)
         $rootResults = $resultMap[$parent] ?? [];
+
+        // If a modified parent query yields no root results, iterate over the whole map instead
+        if($this->modifyQueryUsing && empty($rootResults)) {
+            // Go one layer deeper to access the results
+            $rootResults = array_merge(...array_values($resultMap));
+        }
+
         foreach ($rootResults as $result) {
             // Build a node and add it to the tree
             $node = $this->buildNode($result, $resultMap, $disabledOptions, $hiddenOptions);

--- a/src/SelectTree.php
+++ b/src/SelectTree.php
@@ -216,7 +216,9 @@ class SelectTree extends Field implements HasAffixActions
             $resultCache[$resultKey]['in_set'] = 1;
             // Move any cached children to the result map
             if(isset($resultCache[$resultKey]['children'])){
-                $resultMap[$resultKey] = array_merge($resultMap[$resultKey], $resultCache[$resultKey]['children']);
+                // Since the result map won't have a key for a given result until it's confirmed to be in the set (i.e. this very moment),
+                // we don't have to preserve the previous value for that key; it is guaranteed to have been unset
+                $resultMap[$resultKey] = $resultCache[$resultKey]['children'];
                 unset($resultCache[$resultKey]['children']);
             }
             $parentKey = $result->{$this->getParentAttribute()};

--- a/src/SelectTree.php
+++ b/src/SelectTree.php
@@ -246,8 +246,6 @@ class SelectTree extends Field implements HasAffixActions
         // Move any remaining children from the cache into the root of the tree, since their parents do not show up in the result set
         $resultMap[$parent] = array_merge(...array_values($orphanedResults));
 
-        debug($resultMap);
-
         // Recursively build the tree starting from the root (null parent)
         $rootResults = $resultMap[$parent] ?? [];
 

--- a/src/SelectTree.php
+++ b/src/SelectTree.php
@@ -206,29 +206,55 @@ class SelectTree extends Field implements HasAffixActions
         // Create a mapping of results by their parent IDs for faster lookup
         $resultMap = [];
 
+        // Create a cache of IDs
+        $resultCache = [];
+
         // Group results by their parent IDs
         foreach ($results as $result) {
-            $parentId = $result->{$this->getParentAttribute()};
-            if (! isset($resultMap[$parentId])) {
-                $resultMap[$parentId] = [];
+            // Cache the result ID as seen
+            $resultCache[$result->id]['in_set'] = 1;
+            // Move any cached children to the result map
+            if(isset($resultCache[$result->id]['children'])){
+                $resultMap[$result->id] = array_merge($resultMap[$result->id], $resultCache[$result->id]['children']);
+                unset($resultCache[$result->id]['children']);
             }
-            $resultMap[$parentId][] = $result;
+            $parentId = $result->{$this->getParentAttribute()};
+            if (! isset($resultCache[$parentId])) {
+                // Before adding results to the map, cache the parentId to hold until the parent is confirmed to be in the result set
+                $resultCache[$parentId]['in_set'] = 0;
+                $resultCache[$parentId]['children'] = [];
+            }
+            if($resultCache[$parentId]['in_set']){
+                // if the parent has been confirmed to be in the set, add directly to result map
+                $resultMap[$parentId][] = $result;
+            } else {
+                // otherwise, hold the result in the children cache until the parent is confirmed to be in the result set
+                $resultCache[$parentId]['children'][] = $result;
+            }
         }
+
+        // Filter the cache for missing parents in the result set and get the children
+        $orphanedResults = array_map(
+            fn($item) => $item['children'],
+            array_filter(
+                $resultCache,
+                fn($item) => !$item['in_set']
+            )
+        );
+
+        // Move any remaining children from the cache into the root of the tree, since their parents do not show up in the result set
+        $resultMap[$parent] = array_merge(...array_values($orphanedResults));
+
+        debug($resultMap);
+
+        // Recursively build the tree starting from the root (null parent)
+        $rootResults = $resultMap[$parent] ?? [];
 
         // Define disabled options
         $disabledOptions = $this->getDisabledOptions();
 
         // Define hidden options
         $hiddenOptions = $this->getHiddenOptions();
-
-        // Recursively build the tree starting from the root (null parent)
-        $rootResults = $resultMap[$parent] ?? [];
-
-        // If a modified parent query yields no root results, iterate over the whole map instead
-        if($this->modifyQueryUsing && empty($rootResults)) {
-            // Go one layer deeper to access the results
-            $rootResults = array_merge(...array_values($resultMap));
-        }
 
         foreach ($rootResults as $result) {
             // Build a node and add it to the tree

--- a/src/SelectTree.php
+++ b/src/SelectTree.php
@@ -211,25 +211,26 @@ class SelectTree extends Field implements HasAffixActions
 
         // Group results by their parent IDs
         foreach ($results as $result) {
-            // Cache the result ID as seen
-            $resultCache[$result->id]['in_set'] = 1;
+            // Cache the result as seen
+            $resultKey = $this->getCustomKey($result);
+            $resultCache[$resultKey]['in_set'] = 1;
             // Move any cached children to the result map
-            if(isset($resultCache[$result->id]['children'])){
-                $resultMap[$result->id] = array_merge($resultMap[$result->id], $resultCache[$result->id]['children']);
-                unset($resultCache[$result->id]['children']);
+            if(isset($resultCache[$resultKey]['children'])){
+                $resultMap[$resultKey] = array_merge($resultMap[$resultKey], $resultCache[$resultKey]['children']);
+                unset($resultCache[$resultKey]['children']);
             }
-            $parentId = $result->{$this->getParentAttribute()};
-            if (! isset($resultCache[$parentId])) {
+            $parentKey = $result->{$this->getParentAttribute()};
+            if (! isset($resultCache[$parentKey])) {
                 // Before adding results to the map, cache the parentId to hold until the parent is confirmed to be in the result set
-                $resultCache[$parentId]['in_set'] = 0;
-                $resultCache[$parentId]['children'] = [];
+                $resultCache[$parentKey]['in_set'] = 0;
+                $resultCache[$parentKey]['children'] = [];
             }
-            if($resultCache[$parentId]['in_set']){
+            if($resultCache[$parentKey]['in_set']){
                 // if the parent has been confirmed to be in the set, add directly to result map
-                $resultMap[$parentId][] = $result;
+                $resultMap[$parentKey][] = $result;
             } else {
                 // otherwise, hold the result in the children cache until the parent is confirmed to be in the result set
-                $resultCache[$parentId]['children'][] = $result;
+                $resultCache[$parentKey]['children'][] = $result;
             }
         }
 

--- a/src/SelectTree.php
+++ b/src/SelectTree.php
@@ -20,6 +20,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
+use Illuminate\Support\LazyCollection;
 use InvalidArgumentException;
 
 class SelectTree extends Field implements HasAffixActions
@@ -85,7 +86,7 @@ class SelectTree extends Field implements HasAffixActions
 
     protected bool $storeResults = false;
 
-    protected Collection|array|null $results = null;
+    protected LazyCollection|array|null $results = null;
 
     protected Closure|bool|null $multiple = null;
 
@@ -179,8 +180,8 @@ class SelectTree extends Field implements HasAffixActions
             $nonNullParentQuery->withTrashed($this->withTrashed);
         }
 
-        $nullParentResults = $nullParentQuery->get();
-        $nonNullParentResults = $nonNullParentQuery->get();
+        $nullParentResults = $nullParentQuery->lazy();
+        $nonNullParentResults = $nonNullParentQuery->lazy();
 
         // Combine the results from both queries
         $combinedResults = $nullParentResults->concat($nonNullParentResults);


### PR DESCRIPTION
Fixes #179 and addresses #178

This approach keeps the original functionality of the `SelectTree` intact by handling the `$resultMap` building differently.
Instead of branching the logic if the initial pass doesn't yield root results, we can use a second `array` as a cache for the hierarchical relationship and integrate the `$resultMap` as the iteration comes across the parents, confirming they are in the `$results`.

Making the map this bit\* more expensive to build has another added benefit - if _the relationship query itself_ is filtered/scoped, the tree will now correctly treat records whose parents don't show up in the `$results` as root results, _without_ having to define `$modifyQueryUsing` or changing `$parentNullValue`.

I wonder if there is a case for only using one query to fetch the results, since designating root results is delegated to the `$resultMap`.

About that I have a question about intended usage, is the `$parentNullValue` supposed to be a value that another record should _never_ have? I can smell the hint of a couple use cases where by setting `$parentNullValue` to the current record's `Id` or a related record's could let us build trees to pick "deep children of the current record".

I'd also like @Baspa to give some input about whether this addresses his concerns thoroughly.

\* actual performance difference not tested
