### PR TITLE
Fix return type

### DIFF
--- a/src/SelectTree.php
+++ b/src/SelectTree.php
@@ -563,7 +563,7 @@ class SelectTree extends Field implements HasAffixActions
         );
     }
 
-    public function getResults(): Collection|array|null
+    public function getResults(): LazyCollection|array|null
     {
         return $this->evaluate($this->results);
     }

--- a/src/SelectTree.php
+++ b/src/SelectTree.php
@@ -96,7 +96,7 @@ class SelectTree extends Field implements HasAffixActions
 
     protected Closure|array|null $getTreeUsing = null;
 
-    protected LazyCollection|array|null $results = null;
+    protected Collection|LazyCollection|array|null $results = null;
 
     protected Closure|bool|null $multiple = null;
 
@@ -563,7 +563,7 @@ class SelectTree extends Field implements HasAffixActions
         );
     }
 
-    public function getResults(): LazyCollection|array|null
+    public function getResults(): Collection|LazyCollection|array|null
     {
         return $this->evaluate($this->results);
     }


### PR DESCRIPTION
In version 4.0.8, the following error occurs:

```
CodeWithDennis\FilamentSelectTree\SelectTree::getResults(): Return value must be of type Illuminate\Support\Collection|array|null, Illuminate\Support\LazyCollection returned
```

This commit updates the return type to ensure compatibility.
