### PR TITLE
Fix event name in x-load attribute

### DIFF
--- a/resources/views/select-tree.blade.php
+++ b/resources/views/select-tree.blade.php
@@ -15,7 +15,7 @@
         wire:key="{{ $getTreeKey() }}"
         wire:ignore
         @if (FilamentView::hasSpaMode(url()->current()))
-            x-load="visible || event (ax-modal-opened)"
+            x-load="visible || event (x-modal-opened)"
         @else
             x-load
         @endif


### PR DESCRIPTION
This PR updates event name for modal opened (from ax-modal-opened to x-modal-opened)