### PR TITLE
php8.5 - fix deprecated null array offset

### DIFF
--- a/src/SelectTree.php
+++ b/src/SelectTree.php
@@ -206,10 +206,8 @@ class SelectTree extends Field implements HasAffixActions
 
     private function buildTreeFromResults($results, $parent = null): Collection
     {
-        // Assign the parent's null value to the $parent variable if it's not null
-        if ($parent == null || $parent == $this->getParentNullValue()) {
-            $parent = $this->getParentNullValue() ?? $parent;
-        }
+        // Assign the parent's null value to the $parent variable if it's not null or default to empty string
+        $parent ??= $this->getParentNullValue() ?? '';
 
         // Create a collection to store the tree
         $tree = collect();
@@ -232,7 +230,8 @@ class SelectTree extends Field implements HasAffixActions
                 $resultMap[$resultKey] = $resultCache[$resultKey]['children'];
                 unset($resultCache[$resultKey]['children']);
             }
-            $parentKey = $result->{$this->getParentAttribute()};
+            // Get the result's parent's key, defaulting to empty string for no parent
+            $parentKey = $result->{$this->getParentAttribute()} ?? '';
             if (! isset($resultCache[$parentKey])) {
                 // Before adding results to the map, cache the parentId to hold until the parent is confirmed to be in the result set
                 $resultCache[$parentKey]['in_set'] = 0;


### PR DESCRIPTION
Debugbar is throwing over a hundred deprecation notices for using null as array offsets, which happens quite frequently in the SelectTree when referring to null parents.

This PR aims to fall back to the empty string when accessing the parentNullValue or the parentKey while building the tree.

Should be backwards compatible with php 8.4 and further back.
The deprecation notices stopped appearing after changing these two lines.