### PR TITLE
Fix: Render extraAttributes on the select-tree component view

### DIFF
--- a/resources/views/select-tree.blade.php
+++ b/resources/views/select-tree.blade.php
@@ -11,6 +11,8 @@
 @endphp
 
 <x-dynamic-component :component="$getFieldWrapperView()" :field="$field">
+    {{ new \Illuminate\View\ComponentAttributeBag($getExtraAttributes()) }}
+
     <div
         wire:key="{{ $getTreeKey() }}"
         wire:ignore


### PR DESCRIPTION
### Description
Currently, when passing custom attributes to the `SelectTree` field using `->extraAttributes(...)`, those attributes are ignored because they are not rendered in the component's Blade view.

This PR fixes this by injecting `$getExtraAttributes()` into the root `<div>` of the `select-tree.blade.php` component.

### Changes
* Added `{{ new \Illuminate\View\ComponentAttributeBag($getExtraAttributes()) }}` to the main wrapper `<div>` in `resources/views/components/select-tree.blade.php`.