### PR TITLE
Add append() and prepend() support for getTreeUsing()

### DIFF
--- a/src/SelectTree.php
+++ b/src/SelectTree.php
@@ -552,7 +552,7 @@ class SelectTree extends Field implements HasAffixActions
 
     public function getTree(): Collection
     {
-        return (Collection::wrap($this->evaluate($this->getTreeUsing)) ?? $this->buildTree())
+        return Collection::wrap($this->evaluate($this->getTreeUsing) ?? $this->buildTree())
             ->when($this->prepend, fn (Collection $tree) => $tree->prepend($this->evaluate($this->prepend)))
             ->when($this->append, fn (Collection $tree) => $tree->push($this->evaluate($this->append)));
     }

--- a/src/SelectTree.php
+++ b/src/SelectTree.php
@@ -550,15 +550,11 @@ class SelectTree extends Field implements HasAffixActions
         return $this;
     }
 
-    public function getTree(): Collection|array
+    public function getTree(): Collection
     {
-        if ($this->getTreeUsing) {
-            return $this->evaluate($this->getTreeUsing);
-        }
-
-        return $this->evaluate($this->buildTree()
+        return Collection::wrap($this->evaluate($this->getTreeUsing)) ?? $this->buildTree()
             ->when($this->prepend, fn (Collection $tree) => $tree->prepend($this->evaluate($this->prepend)))
-            ->when($this->append, fn (Collection $tree) => $tree->push($this->evaluate($this->append)))
+            ->when($this->append, fn (Collection $tree) => $tree->push($this->evaluate($this->append))
         );
     }
 

--- a/src/SelectTree.php
+++ b/src/SelectTree.php
@@ -552,10 +552,9 @@ class SelectTree extends Field implements HasAffixActions
 
     public function getTree(): Collection
     {
-        return Collection::wrap($this->evaluate($this->getTreeUsing)) ?? $this->buildTree()
+        return (Collection::wrap($this->evaluate($this->getTreeUsing)) ?? $this->buildTree())
             ->when($this->prepend, fn (Collection $tree) => $tree->prepend($this->evaluate($this->prepend)))
-            ->when($this->append, fn (Collection $tree) => $tree->push($this->evaluate($this->append))
-        );
+            ->when($this->append, fn (Collection $tree) => $tree->push($this->evaluate($this->append)));
     }
 
     public function getResults(): Collection|LazyCollection|array|null


### PR DESCRIPTION
At present, defining `getTreeUsing()` ignores any items `append()`ed or `prepend()`ed to the tree.
This is limiting when `getTreeUsing()` is a `Closure` that doesn't necessarily map to a relationship,
but we still want control over appended and prepended items to the tree generated by the `Closure`.

In my use case, I'm generating a complex tree body with a `Closure` that I reuse in two `SelectTree`s in the `Schema`,
but I append/prepend different static items to the generated body.

Since I'm `wrap()`ping the `getTreeUsing` evaluation with a `Collection` in order to use the `when()` chain method calls to `append()` and `prepend()` items, I've also removed `array` from `getTree()`'s return types.