### PR TITLE
Fix/select tree modify query subtree

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,20 +47,72 @@ SelectTree::make('category_id')
     ->query(fn() => Category::query(), 'name', 'parent_id')
 ```
 
-## Custom Query
+## Query scoping
 
-Customize the parent query
+### `scopeRelationshipQueryUsing`
+
+Runs on **every** query used to build the tree: walking descendants, loading root rows, and loading child rows. Put **tenant or locale filters**, **`select()`**, **`with()`**, and any constraint that must hold for **all** nodes here.
 
 ```php
+use CodeWithDennis\FilamentSelectTree\SelectTree;
+use Illuminate\Database\Eloquent\Builder;
+
 SelectTree::make('categories')
-    ->relationship(relationship: 'categories', titleAttribute: 'name', parentAttribute: 'parent_id', modifyQueryUsing: fn($query) => $query));
+    ->scopeRelationshipQueryUsing(
+        fn (Builder $query): Builder => $query->where('language_code', app()->getLocale())
+    )
+    ->relationship('categories', 'name', 'parent_id');
 ```
 
-Customize the child query
+Add tenant or team scoping the same way (e.g. `whereBelongsTo($tenant)` or `where('tenant_id', …)`).
+
+If you narrow columns, include at least the tree key, parent column, title attribute, and any column used by `withKey()`:
 
 ```php
+use CodeWithDennis\FilamentSelectTree\SelectTree;
+use Illuminate\Database\Eloquent\Builder;
+
 SelectTree::make('categories')
-    ->relationship(relationship: 'categories', titleAttribute: 'name', parentAttribute: 'parent_id', modifyChildQueryUsing: fn($query) => $query));
+    ->scopeRelationshipQueryUsing(
+        fn (Builder $query): Builder => $query->select(['id', 'parent_id', 'name'])
+    )
+    ->relationship('categories', 'name', 'parent_id');
+```
+
+### `modifyQueryUsing`
+
+Optional. When set, it runs **only** on a clone of the **root** query to decide which root records seed each subtree (then IDs are clamped with `whereIn`). It is **not** merged into descendant queries—using root-only conditions as if they applied globally would contradict child rows and hide branches.
+
+Use it for extra filters on which nodes count as roots (e.g. only published roots), and keep shared rules in `scopeRelationshipQueryUsing`.
+
+```php
+use CodeWithDennis\FilamentSelectTree\SelectTree;
+use Illuminate\Database\Eloquent\Builder;
+
+SelectTree::make('categories')
+    ->relationship(
+        relationship: 'categories',
+        titleAttribute: 'name',
+        parentAttribute: 'parent_id',
+        modifyQueryUsing: fn (Builder $query): Builder => $query->where('is_featured', true),
+    );
+```
+
+### `modifyChildQueryUsing`
+
+Runs only on the **non-root** query (rows whose parent is not the null parent value), after subtree clamping when `modifyQueryUsing` is used.
+
+```php
+use CodeWithDennis\FilamentSelectTree\SelectTree;
+use Illuminate\Database\Eloquent\Builder;
+
+SelectTree::make('categories')
+    ->relationship(
+        relationship: 'categories',
+        titleAttribute: 'name',
+        parentAttribute: 'parent_id',
+        modifyChildQueryUsing: fn (Builder $query): Builder => $query->orderBy('sort_order'),
+    );
 ```
 
 ## Methods

--- a/src/SelectTree.php
+++ b/src/SelectTree.php
@@ -72,6 +72,12 @@ class SelectTree extends Field implements HasAffixActions
 
     protected ?Closure $modifyChildQueryUsing = null;
 
+    /**
+     * Runs on every tree query (descendant walk and both final loads). Use for tenant, locale,
+     * narrowed columns, eager loads, etc. Put shared constraints here instead of {@see modifyQueryUsing}.
+     */
+    protected ?Closure $scopeRelationshipQueryUsing = null;
+
     protected Closure|int $defaultOpenLevel = 0;
 
     protected string $direction = 'auto';
@@ -169,14 +175,29 @@ class SelectTree extends Field implements HasAffixActions
         $this->treeKey('treeKey-'.rand());
     }
 
+    /**
+     * Fresh {@see getQuery()} clone with {@see scopeRelationshipQueryUsing} applied when set.
+     */
+    protected function newRelationshipQuery(): Builder
+    {
+        $query = $this->getQuery()->clone();
+
+        if ($this->scopeRelationshipQueryUsing) {
+            $modified = $this->evaluate($this->scopeRelationshipQueryUsing, ['query' => $query]);
+            $query = $modified ?? $query;
+        }
+
+        return $query;
+    }
+
     protected function buildTree(): Collection
     {
         $parentAttribute = $this->getParentAttribute();
         $parentNullValue = $this->getParentNullValue();
         $keyName = $this->getQuery()->getModel()->getKeyName();
 
-        $nullParentQuery = $this->getQuery()->clone()->where($parentAttribute, $parentNullValue);
-        $nonNullParentQuery = $this->getQuery()->clone()->whereNot($parentAttribute, $parentNullValue);
+        $nullParentQuery = $this->newRelationshipQuery()->where($parentAttribute, $parentNullValue);
+        $nonNullParentQuery = $this->newRelationshipQuery()->whereNot($parentAttribute, $parentNullValue);
 
         if ($this->modifyQueryUsing) {
             $rootQuery = $nullParentQuery->clone();
@@ -238,7 +259,7 @@ class SelectTree extends Field implements HasAffixActions
         $frontier = array_values(array_unique($rootIds, SORT_REGULAR));
 
         while ($frontier !== []) {
-            $childQuery = $this->getQuery()->clone()->whereIn($parentAttribute, $frontier);
+            $childQuery = $this->newRelationshipQuery()->whereIn($parentAttribute, $frontier);
 
             if ($this->withTrashed) {
                 $childQuery->withTrashed($this->withTrashed);
@@ -372,6 +393,16 @@ class SelectTree extends Field implements HasAffixActions
         $this->parentAttribute = $parentAttribute;
         $this->modifyQueryUsing = $modifyQueryUsing;
         $this->modifyChildQueryUsing = $modifyChildQueryUsing;
+
+        return $this;
+    }
+
+    /**
+     * @param  ?Closure(array{query: Builder}): (Builder|null)  $callback
+     */
+    public function scopeRelationshipQueryUsing(?Closure $callback): static
+    {
+        $this->scopeRelationshipQueryUsing = $callback;
 
         return $this;
     }

--- a/src/SelectTree.php
+++ b/src/SelectTree.php
@@ -446,7 +446,7 @@ class SelectTree extends Field implements HasAffixActions
         } elseif (is_null($this->append)) {
             // Avoid throwing an exception in case $append is explicitly set to null, or a Closure evaluates to null.
         } else {
-            throw new \InvalidArgumentException('The provided append value must be an array with "name" and "value" keys.');
+            throw new InvalidArgumentException('The provided append value must be an array with "name" and "value" keys.');
         }
 
         return $this;

--- a/src/SelectTree.php
+++ b/src/SelectTree.php
@@ -171,18 +171,36 @@ class SelectTree extends Field implements HasAffixActions
 
     protected function buildTree(): Collection
     {
-        // Start with two separate query builders
-        $nullParentQuery = $this->getQuery()->clone()->where($this->getParentAttribute(), $this->getParentNullValue());
-        $nonNullParentQuery = $this->getQuery()->clone()->whereNot($this->getParentAttribute(), $this->getParentNullValue());
+        $parentAttribute = $this->getParentAttribute();
+        $parentNullValue = $this->getParentNullValue();
+        $keyName = $this->getQuery()->getModel()->getKeyName();
 
-        // If we're not at the root level and a modification callback is provided, apply it to null query
+        $nullParentQuery = $this->getQuery()->clone()->where($parentAttribute, $parentNullValue);
+        $nonNullParentQuery = $this->getQuery()->clone()->whereNot($parentAttribute, $parentNullValue);
+
         if ($this->modifyQueryUsing) {
-            $nullParentQuery = $this->evaluate($this->modifyQueryUsing, ['query' => $nullParentQuery]);
+            $rootQuery = $nullParentQuery->clone();
+            $modified = $this->evaluate($this->modifyQueryUsing, ['query' => $rootQuery]);
+            $rootQuery = $modified ?? $rootQuery;
+
+            if ($this->withTrashed) {
+                $rootQuery->withTrashed($this->withTrashed);
+            }
+
+            $rootIds = $rootQuery->pluck($keyName)->all();
+            $subtreeIds = $this->collectIdsInSubtrees($rootIds);
+
+            if ($subtreeIds === []) {
+                return $this->buildTreeFromResults(collect());
+            }
+
+            $nullParentQuery->whereIn($keyName, $subtreeIds);
+            $nonNullParentQuery->whereIn($keyName, $subtreeIds);
         }
 
-        // If we're at the child level and a modification callback is provided, apply it to non null query
         if ($this->modifyChildQueryUsing) {
-            $nonNullParentQuery = $this->evaluate($this->modifyChildQueryUsing, ['query' => $nonNullParentQuery]);
+            $modified = $this->evaluate($this->modifyChildQueryUsing, ['query' => $nonNullParentQuery]);
+            $nonNullParentQuery = $modified ?? $nonNullParentQuery;
         }
 
         if ($this->withTrashed) {
@@ -202,6 +220,42 @@ class SelectTree extends Field implements HasAffixActions
         }
 
         return $this->buildTreeFromResults($combinedResults);
+    }
+
+    /**
+     * @param  array<int|string>  $rootIds
+     * @return array<int|string>
+     */
+    protected function collectIdsInSubtrees(array $rootIds): array
+    {
+        if ($rootIds === []) {
+            return [];
+        }
+
+        $parentAttribute = $this->getParentAttribute();
+        $keyName = $this->getQuery()->getModel()->getKeyName();
+        $allIds = collect($rootIds);
+        $frontier = array_values(array_unique($rootIds, SORT_REGULAR));
+
+        while ($frontier !== []) {
+            $childQuery = $this->getQuery()->clone()->whereIn($parentAttribute, $frontier);
+
+            if ($this->withTrashed) {
+                $childQuery->withTrashed($this->withTrashed);
+            }
+
+            $children = $childQuery->pluck($keyName)->all();
+            $newIds = array_values(array_diff($children, $allIds->all()));
+
+            if ($newIds === []) {
+                break;
+            }
+
+            $frontier = $newIds;
+            $allIds = $allIds->merge($newIds);
+        }
+
+        return $allIds->unique()->values()->all();
     }
 
     private function buildTreeFromResults($results, $parent = null): Collection


### PR DESCRIPTION
## Summary

`SelectTree` builds options from **two** Eloquent queries: one for **root** rows (`parent_id` is null) and one for **non-root** rows. Previously, `modifyQueryUsing` only applied to the root query. The non-root query still loaded **all** related records with a parent, so unrelated branches could appear and `buildTreeFromResults` could place nodes incorrectly.

This PR, when `modifyQueryUsing` is present, resolves matching root primary keys, walks descendants via the `parent_id` graph, and constrains **both** queries with `whereIn` on that id set so only the intended subtree is loaded. Behavior without `modifyQueryUsing` is unchanged from `4.x`.

---

## Example usage

Limit the picker to the category branch rooted at `id = 1`, including all descendants:

```php
SelectTree::make('category_id')
    ->label('Category')
    ->clearable(false)
    ->searchable(false)
    ->relationship(
        'category',
        'name',
        'parent_id',
        function ($query) {
            return $query->where('id', 1);
        },
        function ($query) {
            return $query;
        },
    )
    ->enableBranchNode(false)
    ->searchable(),
```

The fourth argument scopes **which roots** participate. The fifth runs only on the non-root query; `return $query` adds no extra constraints.

---

## Previous behavior (technical)

**Query A — roots**

```php
Category::query()->where('parent_id', null);
// + modifyQueryUsing, e.g. ->where('id', 1)
```

**Query B — non-roots**

```php
Category::query()->where('parent_id', '!=', null);
// modifyQueryUsing was not applied; only modifyChildQueryUsing, if any
```

With `where('id', 1)` on A only, A returned the single root, while B returned every non-root row in the relation. Descendants of that root appeared because they were included in B, but so could any other non-root row.

---

## Timeline

1. **Pre-`7e57336`:** Two-query layout; modifier on roots only → subtree intent **leaked** via unscoped B.
2. **`7e57336` (Baspa):** Single full query with the modifier on the entire builder → `where('id', 1)` returned **one row**; descendants required an explicit wider predicate.
3. **`31efbc6` (revert):** Restored two-query / root-only modifier → leak returned.
4. **This PR:** Root modifier unchanged in purpose; **both** queries restricted to ids reachable from matched roots.

---

## Risks

- Callers that depended on “filter roots but load every non-root row” will see fewer options; that pattern was inconsistent with subtree selection.
- Constraints applied **only** in `modifyQueryUsing` are not automatically re-run on each descendant fetch; use model global scopes or a shared base query on `SelectTree` when a predicate must apply to every row.

---

## No `modifyQueryUsing`

If the fourth argument is omitted, queries match current `4.x` (full relation, split roots / non-roots).