### PR TITLE
defer Closure evaluation for append() and prepend()

### DIFF
--- a/src/SelectTree.php
+++ b/src/SelectTree.php
@@ -370,30 +370,14 @@ class SelectTree extends Field implements HasAffixActions
 
     public function prepend(Closure|array|null $prepend = null): static
     {
-        $this->prepend = $this->evaluate($prepend);
-
-        if (is_array($this->prepend) && isset($this->prepend['name'], $this->prepend['value'])) {
-            $this->prepend['value'] = (string) $this->prepend['value'];
-        } elseif (is_null($this->prepend)) {
-            // Avoid throwing an exception in case $prepend is explicitly set to null, or a Closure evaluates to null.
-        } else {
-            throw new InvalidArgumentException('The provided prepend value must be an array with "name" and "value" keys.');
-        }
+        $this->prepend = $prepend;
 
         return $this;
     }
 
     public function append(Closure|array|null $append = null): static
     {
-        $this->append = $this->evaluate($append);
-
-        if (is_array($this->append) && isset($this->append['name'], $this->append['value'])) {
-            $this->append['value'] = (string) $this->append['value'];
-        } elseif (is_null($this->append)) {
-            // Avoid throwing an exception in case $append is explicitly set to null, or a Closure evaluates to null.
-        } else {
-            throw new \InvalidArgumentException('The provided append value must be an array with "name" and "value" keys.');
-        }
+        $this->append = $append;
 
         return $this;
     }
@@ -553,8 +537,8 @@ class SelectTree extends Field implements HasAffixActions
     public function getTree(): Collection
     {
         return Collection::wrap($this->evaluate($this->getTreeUsing) ?? $this->buildTree())
-            ->when($this->prepend, fn (Collection $tree) => $tree->prepend($this->evaluate($this->prepend)))
-            ->when($this->append, fn (Collection $tree) => $tree->push($this->evaluate($this->append)));
+            ->when(filled($this->prepend), fn(Collection $tree) => $tree->prepend($this->getPrependedItems()))
+            ->when(filled($this->append), fn(Collection $tree) => $tree->push($this->getAppendedItems()));
     }
 
     public function getResults(): Collection|LazyCollection|array|null
@@ -604,6 +588,36 @@ class SelectTree extends Field implements HasAffixActions
         return $this->evaluate(
             is_null($this->multiple) ? $this->getRelationship() instanceof BelongsToMany : $this->evaluate($this->multiple)
         );
+    }
+
+    public function getPrependedItems(): ?array
+    {
+        $prependedItems = $this->evaluate($this->prepend);
+
+        if (is_array($prependedItems) && isset($prependedItems['name'], $prependedItems['value'])) {
+            $prependedItems['value'] = (string) $prependedItems['value'];
+        } elseif (is_null($prependedItems)) {
+            // Avoid throwing an exception in case $prepend is explicitly set to null, or a Closure evaluates to null.
+        } else {
+            throw new InvalidArgumentException('The provided prepend value must be an array with "name" and "value" keys.');
+        }
+
+        return $prependedItems;
+    }
+
+    public function getAppendedItems(): ?array
+    {
+        $appendedItems = $this->evaluate($this->append);
+
+        if (is_array($appendedItems) && isset($appendedItems['name'], $appendedItems['value'])) {
+            $appendedItems['value'] = (string) $appendedItems['value'];
+        } elseif (is_null($appendedItems)) {
+            // Avoid throwing an exception in case $append is explicitly set to null, or a Closure evaluates to null.
+        } else {
+            throw new \InvalidArgumentException('The provided append value must be an array with "name" and "value" keys.');
+        }
+
+        return $appendedItems;
     }
 
     public function getShowTags(): bool


### PR DESCRIPTION
Currently, the `prepend()` and `append()` methods evaluate a `Closure` passed to them as soon as it is given.
This creates issues when we want to inject utilities such as `$livewire` in the `Closure` - it will throw an `Exception` along the lines of "$container must not be accessed before initialization".

With this PR, two new methods are added:

- `getAppendedItems()`, which evaluates `$this->append` and performs the checks on the value that were moved from `append()`
- `getPrependedItems()`, which evaluates `$this->prepend` and performs the checks on the value that were moved from `prepend()`

Then, in `getTree()`, we wrap `$this->append` and `$this->prepend` in a `filled()` call, so that the `when()` does not evaluate the `Closure` prematurely, and we use the two new methods to retrieve the appended/prepended values, with checks, only if they need to be added to the tree.

I have another change lined up that depends on this deferral of the `Closure` evaluation to handle multiple appended/prepended values, but I chose to separate the two since this is more of a bugfix while the other is an enhancement.