### PR TITLE
feat: multiple appended/prepended items

### DIFF
--- a/src/SelectTree.php
+++ b/src/SelectTree.php
@@ -537,8 +537,8 @@ class SelectTree extends Field implements HasAffixActions
     public function getTree(): Collection
     {
         return Collection::wrap($this->evaluate($this->getTreeUsing) ?? $this->buildTree())
-            ->when(filled($this->prepend), fn(Collection $tree) => $tree->prepend($this->getPrependedItems()))
-            ->when(filled($this->append), fn(Collection $tree) => $tree->push($this->getAppendedItems()));
+            ->when(filled($this->prepend), fn(Collection $tree) => $tree->unshift(...$this->generatePrependedItems()))
+            ->when(filled($this->append), fn(Collection $tree) => $tree->push(...$this->generateAppendedItems()));
     }
 
     public function getResults(): Collection|LazyCollection|array|null
@@ -590,34 +590,60 @@ class SelectTree extends Field implements HasAffixActions
         );
     }
 
-    public function getPrependedItems(): ?array
+    protected function generatePrependedItems(): \Generator
     {
         $prependedItems = $this->evaluate($this->prepend);
 
-        if (is_array($prependedItems) && isset($prependedItems['name'], $prependedItems['value'])) {
-            $prependedItems['value'] = (string) $prependedItems['value'];
+        if (is_array($prependedItems)) {
+            if (isset($prependedItems['name'], $prependedItems['value'])) {
+                $prependedItems['value'] = (string) $prependedItems['value'];
+                yield $prependedItems;
+            } elseif (is_array($prependedItems[0])) {
+                foreach ($prependedItems as $prependedItem) {
+                    if (isset($prependedItem['name'], $prependedItem['value'])) {
+                        $prependedItem['value'] = (string) $prependedItem['value'];
+                        yield $prependedItem;
+                    }
+                }
+            }
         } elseif (is_null($prependedItems)) {
             // Avoid throwing an exception in case $prepend is explicitly set to null, or a Closure evaluates to null.
         } else {
-            throw new InvalidArgumentException('The provided prepend value must be an array with "name" and "value" keys.');
+            throw new InvalidArgumentException('The provided prepend value must be an array or an array of arrays with "name" and "value" keys.');
         }
+    }
 
-        return $prependedItems;
+    public function getPrependedItems(): ?array
+    {
+        return iterator_to_array($this->generatePrependedItems());
+    }
+
+    protected function generateAppendedItems(): \Generator
+    {
+        $appendedItems = $this->evaluate($this->append);
+
+        if (is_array($appendedItems)) {
+            if (isset($appendedItems['name'], $appendedItems['value'])) {
+                $appendedItems['value'] = (string) $appendedItems['value'];
+                yield $appendedItems;
+            } elseif (is_array($appendedItems[0])) {
+                foreach ($appendedItems as $appendedItem) {
+                    if (isset($appendedItem['name'], $appendedItem['value'])) {
+                        $appendedItem['value'] = (string) $appendedItem['value'];
+                        yield $appendedItem;
+                    }
+                }
+            }
+        } elseif (is_null($appendedItems)) {
+            // Avoid throwing an exception in case $append is explicitly set to null, or a Closure evaluates to null.
+        } else {
+            throw new InvalidArgumentException('The provided append value must be an array or an array of arrays with "name" and "value" keys.');
+        }
     }
 
     public function getAppendedItems(): ?array
     {
-        $appendedItems = $this->evaluate($this->append);
-
-        if (is_array($appendedItems) && isset($appendedItems['name'], $appendedItems['value'])) {
-            $appendedItems['value'] = (string) $appendedItems['value'];
-        } elseif (is_null($appendedItems)) {
-            // Avoid throwing an exception in case $append is explicitly set to null, or a Closure evaluates to null.
-        } else {
-            throw new \InvalidArgumentException('The provided append value must be an array with "name" and "value" keys.');
-        }
-
-        return $appendedItems;
+        return iterator_to_array($this->generateAppendedItems());
     }
 
     public function getShowTags(): bool


### PR DESCRIPTION
Currently, `append()` and `prepend()` accept an `array` or `Closure` to append/prepend _one_ item to the tree.

This limitation is due to two factors:

- Previously in those same functions, and more recently in `getAppendedItems()` and `getPrependedItems()`, there is a hard check for  `'value'` and `'name'` keys in the supplied `array` or the `array` the `Closure` is expected to resolve to.

- `Collection`'s `prepend` method expects exactly one `$value`, and `push`'s `...$value` is a variadic parameter, so passing a nested `array` to it would break the structure of the tree.


The solution is to use `Generator`s:

- two new `protected` methods, `generatePrependedItems()` and `generateAppendedItems()` have been added, to `yield` multiple tree elements from `$this->prepend` and `$this->append`, be they an `array` or a `Closure`.

- in `getTree()`, by using `unshift()` instead of `prepend()`, multiple values can be prepended. By using the `...` unpacking operator on the new `Generator`s, the values are `yield`ed and fed into the methods like a variadic parameter.

- the logic in `getAppendedItems()` and `getPrependedItems()` has been deferred to the `Generator`s, and those helpers now fetch the resolved items from them.

Naturally, this change is strictly an enhancement and does not introduce regressions to my knowledge (local manual testing), single-item append/prepend is handled as it has been.


This PR needs to:

- merge the latest upstream PR

- update documentation


I'd move along with those two points if the feature is greenlit.