### PR TITLE
feat: toggle strict null parent root nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,16 @@ SelectTree::make('categories')
     ->relationship(relationship: 'categories', titleAttribute: 'name', parentAttribute: 'parent_id', modifyChildQueryUsing: fn($query) => $query));
 ```
 
+Note: when you filter the parent query, any results found by the child query whose parents have been filtered out will be promoted to root nodes by default (to prevent empty result sets).
+To disable this feature, use the `strictNullParentRootNodes()` configuration method
+
+```php
+SelectTree::make('categories')
+    ->relationship(relationship: 'categories', titleAttribute: 'name', parentAttribute: 'parent_id', modifyQueryUsing: fn($query) => $query->where('id', 1))
+    ->strictNullParentRootNodes(); // only children of parent results from the parent query will be included in the tree
+```
+
+
 ## Methods
 
 Set a custom placeholder when no items are selected

--- a/src/SelectTree.php
+++ b/src/SelectTree.php
@@ -248,22 +248,23 @@ class SelectTree extends Field implements HasAffixActions
             }
         }
 
-        if (! $this->hasStrictNullParentRootNodes()) {
+        // If the tree has strict rull parent root nodes, only retrieve children whose parent is the null value
+        // Otherwise, promote other orphaned children to root nodes
+        $orphanedResults = $this->hasStrictNullParentRootNodes()
+        ? [$parent => $resultCache[$parent]['children']]
+        : array_map(
+            fn ($item) => $item['children'],
+            array_filter(
+                $resultCache,
+                fn ($item) => ! $item['in_set']
+            )
+        );
 
-            // Filter the cache for missing parents in the result set and get the children
-            $orphanedResults = array_map(
-                fn ($item) => $item['children'],
-                array_filter(
-                    $resultCache,
-                    fn ($item) => ! $item['in_set']
-                )
-            );
+        // Move any remaining children from the cache into the root of the tree, since their parents do not show up in the result set
 
-            // Move any remaining children from the cache into the root of the tree, since their parents do not show up in the result set
-            $resultMap[$parent] = [];
-            foreach ($orphanedResults as $orphanedResult) {
-                $resultMap[$parent] += $orphanedResult;
-            }
+        $resultMap[$parent] = [];
+        foreach ($orphanedResults as $orphanedResult) {
+            $resultMap[$parent] += $orphanedResult;
         }
 
         // Recursively build the tree starting from the root (null parent)

--- a/src/SelectTree.php
+++ b/src/SelectTree.php
@@ -72,6 +72,8 @@ class SelectTree extends Field implements HasAffixActions
 
     protected ?Closure $modifyChildQueryUsing = null;
 
+    protected Closure|bool $strictNullParentRootNodes = false;
+
     protected Closure|int $defaultOpenLevel = 0;
 
     protected string $direction = 'auto';
@@ -246,19 +248,22 @@ class SelectTree extends Field implements HasAffixActions
             }
         }
 
-        // Filter the cache for missing parents in the result set and get the children
-        $orphanedResults = array_map(
-            fn ($item) => $item['children'],
-            array_filter(
-                $resultCache,
-                fn ($item) => ! $item['in_set']
-            )
-        );
+        if (! $this->hasStrictNullParentRootNodes()) {
 
-        // Move any remaining children from the cache into the root of the tree, since their parents do not show up in the result set
-        $resultMap[$parent] = [];
-        foreach ($orphanedResults as $orphanedResult) {
-            $resultMap[$parent] += $orphanedResult;
+            // Filter the cache for missing parents in the result set and get the children
+            $orphanedResults = array_map(
+                fn ($item) => $item['children'],
+                array_filter(
+                    $resultCache,
+                    fn ($item) => ! $item['in_set']
+                )
+            );
+
+            // Move any remaining children from the cache into the root of the tree, since their parents do not show up in the result set
+            $resultMap[$parent] = [];
+            foreach ($orphanedResults as $orphanedResult) {
+                $resultMap[$parent] += $orphanedResult;
+            }
         }
 
         // Recursively build the tree starting from the root (null parent)
@@ -333,6 +338,13 @@ class SelectTree extends Field implements HasAffixActions
         return $this;
     }
 
+    public function strictNullParentRootNodes(Closure|bool $condition = true): static
+    {
+        $this->strictNullParentRootNodes = $condition;
+
+        return $this;
+    }
+
     public function withCount(bool $withCount = true): static
     {
         $this->withCount = $withCount;
@@ -398,6 +410,11 @@ class SelectTree extends Field implements HasAffixActions
         }
 
         return $this->getRelationship()->getRelated()->query();
+    }
+
+    public function hasStrictNullParentRootNodes(): bool
+    {
+        return $this->evaluate($this->strictNullParentRootNodes);
     }
 
     public function getTitleAttribute(): string


### PR DESCRIPTION
As per #212, here is a draft of my suggestion.
By using the `strictNullParentRootNodes()` configuration method, the `buildTree()` method will not turn orphaned child nodes into root nodes. An `hasStrictNullParentRootNodes()` helper has been added to this end.
Needs documentation update.
Consider calling the configuration method by default in `relationship()` on a major version change.